### PR TITLE
Run UI tests on a regular schedule

### DIFF
--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -4,6 +4,10 @@ on:
   push: 
     branches:
       - master
+  schedule:
+    # Scheduled at 18:30 PM UTC (Sunday to Thursday)
+    # Scheduled at 12:00 AM IST (Monday to Friday)
+    - cron: "30 23 * * 0-4"
 
 jobs:
   run_checks:


### PR DESCRIPTION
This uses the GitHub Actions schedule event (https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#scheduled-events-schedule) to run the UI tests at 12 AM IST every weekday.